### PR TITLE
[rust] Add ability to fetch master/main (and add cfg file to help)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -321,6 +321,8 @@ dependencies = [
  "clap",
  "futures",
  "octocrab",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,3 +11,5 @@ octocrab = "0.9"
 futures = "0.3"
 tokio = {version = "1.12.0", features = ["full"] }
 tempfile = "3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,0 +1,37 @@
+
+use serde::{Deserialize, Serialize};
+use std::io::Read;
+use std::process::Command;
+use std::str::from_utf8;
+use std::fs::File;
+use std::path::{Path};
+
+
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    pub repo_main_branch: String,
+} 
+
+pub fn get_config() -> Config {
+    let path = Path::new(get_repo_root_path().as_str()).join(".git").join("GG_CONFIG");
+    let mut file = File::open(path).expect("WANT IT!!!");
+    let mut buf = String::new();
+    file.read_to_string(&mut buf).expect("no error reading!");
+    let c: Config = serde_json::from_str(buf.as_str()).expect("res!");
+    return c;
+}
+
+fn get_repo_root_path() -> String {
+    let out = match Command::new("git")
+            .arg("rev-parse")
+            .arg("--show-toplevel")
+            .output() {
+                Ok(output) => output,
+                Err(_e) => panic!("error!")
+    };
+    let x: &[_] = &[' ', '\t', '\n', '\r'];
+    let result = from_utf8(&out.stdout)
+        .expect("msg")
+        .trim_end_matches(x);
+    return result.to_string()
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,5 @@
 #[path = "pr.rs"] mod pr;
+#[path = "config.rs"] mod config;
 use clap::{App, Arg};
 use std::process::Command;
 use std::str::from_utf8;
@@ -28,6 +29,9 @@ async fn main() ->  Result<(), Box<dyn std::error::Error>> {
         .subcommand(App::new("pr")
             .about("creates a PR for the current branch")
         )
+        .subcommand(App::new("fetch")
+            .about("fetches the current master/main branch")
+        )
         .get_matches();
 
     if let Some(ref matches) = matches.subcommand_matches("new") {
@@ -43,6 +47,9 @@ async fn main() ->  Result<(), Box<dyn std::error::Error>> {
         let branch = current_branch();
         push(branch.clone(), true);
         pr::create_pr(branch).await.expect("error creating PR");
+    }
+    if let Some(ref _matches) = matches.subcommand_matches("fetch") {
+        fetch_main()
     }
     Ok(())
 }
@@ -86,4 +93,15 @@ fn push(full_branch: String, force: bool) {
      .arg(full_branch)
      .output()
      .expect("failed to push branch");
+}
+
+fn fetch_main() {
+    let cfg = config::get_config();
+    Command::new("git")
+            .arg("fetch")
+            .arg("-p")
+            .arg("origin")
+            .arg(cfg.repo_main_branch)
+            .output()
+            .expect("failed to fetch main branch");
 }

--- a/rust/src/pr.rs
+++ b/rust/src/pr.rs
@@ -26,7 +26,7 @@ fn get_title_and_body(branch: String) -> (String, String) {
     (title.to_string(), body.to_string())
 }
 
-fn get_git_log_for_branch(branch: String) -> String {
+fn get_git_log_for_branch(_branch: String) -> String {
     let out = match Command::new("git")
             .arg("log")
             .arg("--pretty=\"%s%+b\"")


### PR DESCRIPTION

Summary: Adds the ability to fetch master/main with a cfg
file that we can prefill with the master/main info (and any other
repo-specific info we want to add).
