### PR TITLE
[rust] Add newline when creating github PR from commit messages

### DIFF
--- a/rust/src/pr.rs
+++ b/rust/src/pr.rs
@@ -52,7 +52,7 @@ fn get_template_for_pr() -> String {
 fn get_git_log_from_base_branch(core_branch: String) -> String {
     let out = match Command::new("git")
             .arg("log")
-            .arg("--pretty=%s%+b")
+            .arg("--pretty=%s%n%+b")
             .arg(format!("origin/{}..HEAD", core_branch))
             .output() {
                 Ok(output) => output,


### PR DESCRIPTION

Summary: Before the line between title and body would get removed.

Resolves Issue: github.com/willhug/gg/issues/95
