### PR TITLE
[rust][tui] Open PR from branches view on enter

### DIFF
--- a/rust/src/terminal/branches.rs
+++ b/rust/src/terminal/branches.rs
@@ -133,6 +133,15 @@ impl App for PullApp {
                 git::checkout(&selected_branch.branch);
                 self.update().await;
             },
+            Key::Char('\n') => {
+                let i = &self.pulls[self.selection];
+                match &i.pr {
+                    Some(pr) => {
+                        open::that(&pr.html_url.as_str()).unwrap();
+                    },
+                    None => {},
+                }
+            }
             _ => {
                 println!("Unknown input!");
             }


### PR DESCRIPTION

Resolves Issue: [[BTerm] Enter takes you to the PR](https://github.com/willhug/gg/issues/115)
