### PR TITLE
[rust] Fix bug on config creation

### DIFF
--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -121,7 +121,7 @@ fn create_saved_config() -> File {
     println!("What will the branch prefix be: ");
     let mut prefix = String::new();
     std::io::stdin().read_line(&mut prefix).unwrap();
-    let prefix = line.trim_end_matches(x);
+    let prefix = prefix.trim_end_matches(x);
 
     let config = SavedConfig {
         repo_main_branch: line.to_string(),


### PR DESCRIPTION

Summary: Had a bug in config creation that would set our prefix to the
repo root branch, which you can't have as a prefix lol.
