### PR TITLE
[rebase] add Fixup command to move tmp branches forward

### DIFF
--- a/rust/src/git_rebase/mod.rs
+++ b/rust/src/git_rebase/mod.rs
@@ -61,6 +61,12 @@ fn rebase_onto(branch_to_rebase: TmpBranchWrapper, onto: String, strategy: Optio
     finish_rebase(branch_to_rebase);
 }
 
+pub(crate) fn fixup_rebase() {
+    let br = TmpBranchWrapper::new_from_tmp_branch(current_branch());
+
+    finish_rebase(br);
+}
+
 fn finish_rebase(br: TmpBranchWrapper) {
     checkout(&br.inner.start());
     reset(br.tmp_start_branch_name(), true);

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -11,7 +11,7 @@ use std::io::{self, Read, Write};
 use anyhow::Result;
 use config::get_saved_config;
 use git::{current_parsed_branch, diff};
-use git_rebase::{abort_rebase, continue_rebase, start_rebase, rebase_all_children};
+use git_rebase::{abort_rebase, continue_rebase, start_rebase, rebase_all_children, fixup_rebase};
 use github::GithubRepo;
 use structopt::{StructOpt};
 
@@ -87,6 +87,8 @@ enum Cmd {
         rebase_abort: bool,
         #[structopt(short="c",long="continue")]
         rebase_continue: bool,
+        #[structopt(short="f",long="fixup")]
+        rebase_fixup: bool,
     },
     #[structopt(about = "Manage issues")]
     Issue(IssueSubcommand),
@@ -301,8 +303,12 @@ async fn main() ->  Result<(), Box<dyn std::error::Error>> {
             strategy,
             rebase_abort,
             rebase_continue ,
+            rebase_fixup,
         } => {
-            if rebase_abort {
+            if rebase_fixup {
+                fixup_rebase();
+                return Ok(())
+            } else if rebase_abort {
                 abort_rebase();
                 return Ok(())
             } else if rebase_continue {


### PR DESCRIPTION

Resolves Issue: [[rebase] Add command to cleanup tmp branches if manually run](https://github.com/willhug/gg/issues/155)
