### PR TITLE
[config][parse] Support configuring the split char for parsed branches

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,6 +23,13 @@ pub struct SavedConfig {
     pub linked_issue: Option<i64>,
     pub branch_prefix: String,
     pub repo_org: String,
+
+    #[serde(default="default_split")]
+    pub branch_split: String,
+}
+
+fn default_split() -> String {
+    "/".to_string()
 }
 
 pub fn get_full_config() -> FullConfig {
@@ -127,11 +134,17 @@ fn create_saved_config() -> File {
     std::io::stdin().read_line(&mut org).unwrap();
     let org = org.trim_end_matches(x);
 
+    println!("What is the split character: ");
+    let mut split = String::new();
+    std::io::stdin().read_line(&mut split).unwrap();
+    let split = split.trim_end_matches(x);
+
     let config = SavedConfig {
         repo_main_branch: line.to_string(),
         linked_issue: None,
         branch_prefix: prefix.to_string(), // replace
         repo_org: org.to_string(),
+        branch_split: split.to_string(),
     };
 
     write_saved_config(config)

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -280,7 +280,7 @@ impl ParsedBranch {
         ].into_iter()
             .flatten()
             .collect();
-        parts.join("/")
+        parts.join(get_saved_config().branch_split.as_str())
     }
 
     pub(crate) fn start(&self) -> String {
@@ -292,7 +292,7 @@ impl ParsedBranch {
         ].into_iter()
             .flatten()
             .collect();
-        parts.join("/")
+        parts.join(get_saved_config().branch_split.as_str())
     }
 
     pub(crate) fn remote_full(&self) -> String {
@@ -313,7 +313,8 @@ impl ParsedBranch {
 }
 
 pub(crate) fn is_start_branch(branch: &String) -> bool {
-    branch.starts_with(format!("{}/{}", get_saved_config().branch_prefix, "starts").as_str())
+    let cfg = get_saved_config();
+    branch.starts_with(format!("{}{}{}", cfg.branch_prefix, cfg.branch_split, "starts").as_str())
 }
 
 pub(crate) fn current_parsed_branch() -> ParsedBranch {
@@ -321,10 +322,11 @@ pub(crate) fn current_parsed_branch() -> ParsedBranch {
 }
 
 pub(crate) fn parse_branch(orig_branch: String) -> ParsedBranch {
-    let prefix = get_saved_config().branch_prefix;
+    let cfg = get_saved_config();
+    let prefix = cfg.branch_prefix;
 
     let mut found_prefix = None;
-    let branch = match orig_branch.split_once(format!("{}/", prefix).as_str()) {
+    let branch = match orig_branch.split_once(format!("{}{}", prefix, cfg.branch_split).as_str()) {
         Some(res) => {
             found_prefix = Some(prefix);
             res.1.to_string()
@@ -332,7 +334,7 @@ pub(crate) fn parse_branch(orig_branch: String) -> ParsedBranch {
         None => orig_branch.clone(),
     };
 
-    match branch.split_once("/part-") {
+    match branch.split_once(format!("{}part-", cfg.branch_split).as_str()) {
         Some(res) => {
             ParsedBranch {
                 prefix: found_prefix,


### PR DESCRIPTION

Resolves Issue: [[parsing] Allow alternates to slashes `/` to separate branch parts.](https://github.com/willhug/gg/issues/164)
